### PR TITLE
Initial Working faradayio-cli utility

### DIFF
--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -3,8 +3,16 @@
 __version__ = "0.0.0"
 
 import sys
+import argparse
 
 from faradayio.faraday import Faraday
 
+def setupArgParse():
+    parser = argparse.ArgumentParser()
+    return parser.parse_args()
+
 def main():
     print("Executing faradayio-cli version {0}".format(__version__))
+
+    # Setup command line arguments
+    args = setupArgParse()

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -31,7 +31,7 @@ def setupSerialPort(loopback, port):
         serialPort = SerialTestClass()
     else:
         # TODO enable serial port command line options (keep simple for user!)
-        serialPort = serial.Serial(port, 115200, timeout=1)
+        serialPort = serial.Serial(port, 115200, timeout=0)
 
     return serialPort
 

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -7,7 +7,7 @@ import argparse
 
 from faradayio.faraday import Faraday
 
-def setupArgParse():
+def setupArgparse():
     parser = argparse.ArgumentParser()
 
     # Required arguments
@@ -24,4 +24,4 @@ def main():
     print("Executing faradayio-cli version {0}".format(__version__))
 
     # Setup command line arguments
-    args = setupArgParse()
+    args = setupArgparse()

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -11,11 +11,12 @@ def setupArgparse():
     parser = argparse.ArgumentParser()
 
     # Required arguments
-    parser.add_argument("callsign", help="Callsign of Faraday radio")
-    parser.add_argument("ID", type=int, help="ID number Faraday radio")
+    parser.add_argument("Callsign", help="Callsign of radio")
+    parser.add_argument("ID", type=int, help="ID number radio")
 
     # Optional arguments
     parser.add_argument("-l", "--loopback", action="store_true", help="Use software loopback serial port")
+    parser.add_argument("-p", "--port", default="dev/ttyUSB0", help="Physical serial port of radio")
 
     # Parse and return arguments
     return parser.parse_args()
@@ -25,3 +26,7 @@ def main():
 
     # Setup command line arguments
     args = setupArgparse()
+
+    print(args)
+    # Setup serial port
+    # setupSerialPort(args.loopback)

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -12,6 +12,7 @@ def setupArgParse():
 
     # Required arguments
     parser.add_argument("callsign", help="Callsign of Faraday radio")
+    parser.add_argument("ID", type=int, help="ID number Faraday radio")
 
     # Parse and return arguments
     return parser.parse_args()

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -37,7 +37,11 @@ def main():
     print("Executing faradayio-cli version {0}".format(__version__))
 
     # Setup command line arguments
-    args = setupArgparse()
+    try:
+        args = setupArgparse()
+
+    except argparse.ArgumentError as error:
+        raise SystemExit(error)
 
     # Setup serial port
     try:

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -6,7 +6,7 @@ import sys
 import argparse
 import serial
 
-from faradayio.faraday import Faraday
+from faradayio.faraday import Monitor
 from faradayio.faraday import SerialTestClass
 
 def setupArgparse():
@@ -52,4 +52,4 @@ def main():
 
     # Setup TUN adapter
     tunName = "{0}-{1}".format(args.callsign.upper(),args.id)
-    # tun = faraday.Monitor(serialPort=serialPort)
+    tun = Monitor(serialPort=serialPort)

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -6,6 +6,7 @@ import sys
 import argparse
 import serial
 import threading
+import time
 
 from faradayio.faraday import Monitor
 from faradayio.faraday import SerialTestClass
@@ -53,5 +54,20 @@ def main():
 
     # Setup TUN adapter
     tunName = "{0}-{1}".format(args.callsign.upper(),args.id)
-    tun = Monitor(serialPort=serialPort, name=tunName)
+
+    isRunning = threading.Event()
+    isRunning.set()
+
+    tun = Monitor(serialPort=serialPort, name=tunName, isRunning=isRunning)
     tun.start()
+
+    try:
+        while True:
+            time.sleep(0.1)
+            print("sleeping...")
+
+    except KeyboardInterrupt:
+        print("stopping threads...")
+        isRunning.clear()
+        tun.join()
+        print("stopped!")

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -5,6 +5,7 @@ __version__ = "0.0.0"
 import sys
 import argparse
 import serial
+import threading
 
 from faradayio.faraday import Monitor
 from faradayio.faraday import SerialTestClass
@@ -52,4 +53,5 @@ def main():
 
     # Setup TUN adapter
     tunName = "{0}-{1}".format(args.callsign.upper(),args.id)
-    tun = Monitor(serialPort=serialPort)
+    tun = Monitor(serialPort=serialPort, name=tunName)
+    tun.start()

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -9,6 +9,11 @@ from faradayio.faraday import Faraday
 
 def setupArgParse():
     parser = argparse.ArgumentParser()
+
+    # Required arguments
+    parser.add_argument("callsign", help="Callsign of Faraday radio")
+
+    # Parse and return arguments
     return parser.parse_args()
 
 def main():

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -40,4 +40,8 @@ def main():
     args = setupArgparse()
 
     # Setup serial port
-    serialPort = setupSerialPort(args.loopback, args.port)
+    try:
+        serialPort = setupSerialPort(args.loopback, args.port)
+
+    except serial.SerialException as error:
+        raise SystemExit(error)

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -4,8 +4,10 @@ __version__ = "0.0.0"
 
 import sys
 import argparse
+import serial
 
 from faradayio.faraday import Faraday
+from faradayio.faraday import SerialTestClass
 
 def setupArgparse():
     parser = argparse.ArgumentParser()
@@ -16,10 +18,20 @@ def setupArgparse():
 
     # Optional arguments
     parser.add_argument("-l", "--loopback", action="store_true", help="Use software loopback serial port")
-    parser.add_argument("-p", "--port", default="dev/ttyUSB0", help="Physical serial port of radio")
+    parser.add_argument("-p", "--port", default="/dev/ttyUSB0", help="Physical serial port of radio")
 
     # Parse and return arguments
     return parser.parse_args()
+
+def setupSerialPort(loopback, port):
+    if loopback:
+        # Implement loopback software serial port
+        serialPort = SerialTestClass()
+    else:
+        # TODO enable serial port command line options (keep simple for user!)
+        serialPort = serial.Serial(port, 115200, timeout=1)
+
+    return serialPort
 
 def main():
     print("Executing faradayio-cli version {0}".format(__version__))
@@ -27,6 +39,5 @@ def main():
     # Setup command line arguments
     args = setupArgparse()
 
-    print(args)
     # Setup serial port
-    # setupSerialPort(args.loopback)
+    serialPort = setupSerialPort(args.loopback, args.port)

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -52,22 +52,23 @@ def main():
     except serial.SerialException as error:
         raise SystemExit(error)
 
-    # Setup TUN adapter
+    # Create TUN adapter name
     tunName = "{0}-{1}".format(args.callsign.upper(),args.id)
 
+    # Create threading event for TUN thread control
+    # set() causes while loop to continuously run until clear() is run
     isRunning = threading.Event()
     isRunning.set()
 
+    # Setup TUN adapter and start
     tun = Monitor(serialPort=serialPort, name=tunName, isRunning=isRunning)
     tun.start()
 
+    # loop infinitely until KeyboardInterrupt, then clear() event to exit thread
     try:
         while True:
             time.sleep(0.1)
-            print("sleeping...")
 
     except KeyboardInterrupt:
-        print("stopping threads...")
-        isRunning.clear()
+        tun.isRunning.clear()
         tun.join()
-        print("stopped!")

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -14,6 +14,9 @@ def setupArgParse():
     parser.add_argument("callsign", help="Callsign of Faraday radio")
     parser.add_argument("ID", type=int, help="ID number Faraday radio")
 
+    # Optional arguments
+    parser.add_argument("-l", "--loopback", action="store_true", help="Use software loopback serial port")
+
     # Parse and return arguments
     return parser.parse_args()
 

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -13,8 +13,8 @@ def setupArgparse():
     parser = argparse.ArgumentParser()
 
     # Required arguments
-    parser.add_argument("Callsign", help="Callsign of radio")
-    parser.add_argument("ID", type=int, help="ID number radio")
+    parser.add_argument("callsign", help="Callsign of radio")
+    parser.add_argument("id", type=int, help="ID number radio")
 
     # Optional arguments
     parser.add_argument("-l", "--loopback", action="store_true", help="Use software loopback serial port")
@@ -45,3 +45,7 @@ def main():
 
     except serial.SerialException as error:
         raise SystemExit(error)
+
+    # Setup TUN adapter
+    tunName = "{0}-{1}".format(args.callsign.upper(),args.id)
+    # tun = faraday.Monitor(serialPort=serialPort)

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -28,7 +28,8 @@ def setupArgparse():
 def setupSerialPort(loopback, port):
     if loopback:
         # Implement loopback software serial port
-        serialPort = SerialTestClass()
+        testSerial = SerialTestClass()
+        serialPort = testSerial.serialPort
     else:
         # TODO enable serial port command line options (keep simple for user!)
         serialPort = serial.Serial(port, 115200, timeout=0)


### PR DESCRIPTION
This PR pulls in branch `issue3` which provides the following changes and requires at a minimum `faradayio` version `0.0.2` to operate.

* Sets-up command line arguments for basic use
* Provides a software serial loopback option
* Implements TUN adapter with threaded operation
* Cleanly exits threads with `KeyboardInterrupt`

This code has been tested both with software loop back as well as physical loopback hardware utilizing a Faraday radio with specific echo firmware install. Additionally, third-part serial loopback hardware also confirms proper operation.