### PR TITLE
Automated Linting on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: python
 python:
 - '3.5'
-install:
-- "~/virtualenv/python3.5/bin/pip3 install -r requirements.txt"
+# install:
+# - "~/virtualenv/python3.5/bin/pip3 install -r requirements.txt"
 script:
 - "~/virtualenv/python3.5/bin/flake8 --exclude docs/ ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: python
 python:
 - '3.5'
-# install:
-# - "~/virtualenv/python3.5/bin/pip3 install -r requirements.txt"
+install:
+- "~/virtualenv/python3.5/bin/pip3 install -r requirements.txt"
 script:
 - "~/virtualenv/python3.5/bin/flake8 --exclude docs/ ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+dist: trusty
+language: python
+python:
+- '3.5'
+install:
+- "~/virtualenv/python3.5/bin/pip3 install -r requirements.txt"
+script:
+- "~/virtualenv/python3.5/bin/flake8 --exclude docs/ ."

--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -43,7 +43,7 @@ def setupSerialPort(loopback, port):
 
     Depending on command line options, this function will either connect to a
     SerialTestClass() port for loopback testing or to the specified port from
-    the command line option. If loopback is True then it overrides physical port
+    the command line option. If loopback is True it overrides the physical port
     specification.
 
     Args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs==17.4.0
-faradayio==0.0.2
+faradayio>=0.0.1
 flake8==3.5.0
 future==0.16.0
 mccabe==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+attrs==17.4.0
+faradayio==0.0.2
+flake8==3.5.0
+future==0.16.0
+mccabe==0.6.1
+pluggy==0.6.0
+py==1.5.2
+pycodestyle==2.3.1
+pyflakes==1.6.0
+pyserial==3.4
+pytest==3.4.1
+python-pytun==2.2.1
+PyYAML==3.12
+six==1.11.0
+sliplib==0.3.0
+sphinx-rtd-theme==0.2.4
+timeout-decorator==0.4.0


### PR DESCRIPTION
Per #12 this PR pulls in automated linting with `flake8`. The following large changes occured:

* Added `.travis.yml` file
* Added `requirements.txt` file
* Installed `requirements.txt` upon CI environment starting up. Installs older `faradayio` which will not unit test!
* Fixed one error on line 46 of a line too long.