### PR TITLE
Update to v0.0.2 and use faradayio v0.0.3

### DIFF
--- a/faradayio_cli/faradayio_cli.py
+++ b/faradayio_cli/faradayio_cli.py
@@ -1,6 +1,6 @@
 """faradayio-cli.faradayio-cli: provides entry point main()."""
 
-__version__ = "0.0.1a"
+__version__ = "0.0.2"
 
 import argparse
 import serial

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs==17.4.0
-faradayio==0.0.2a
+faradayio==0.0.3
 flake8==3.5.0
 mccabe==0.6.1
 pluggy==0.6.0


### PR DESCRIPTION
Fix erroneous version requirements and work correctly with Github and Pypi versioning.